### PR TITLE
Tycho build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions>
+	<extension>
+		<groupId>org.eclipse.tycho.extras</groupId>
+		<artifactId>tycho-pomless</artifactId>
+		<version>1.3.0</version>
+	</extension>
+</extensions>
+

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>openapi-metamodel</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/edu.uoc.som.openapi.feature/.gitignore
+++ b/features/edu.uoc.som.openapi.feature/.gitignore
@@ -1,2 +1,1 @@
-bin/
 target/

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -1,0 +1,18 @@
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>features</artifactId>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>edu.uoc.som.openapi</groupId>
+		<artifactId>openapi-metamodel</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+
+	</parent>
+
+	<modules>
+		<module>edu.uoc.som.openapi.feature</module>
+	</modules>
+</project>
+

--- a/plugins/edu.uoc.som.openapi.io/.gitignore
+++ b/plugins/edu.uoc.som.openapi.io/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+/target/

--- a/plugins/edu.uoc.som.openapi/.gitignore
+++ b/plugins/edu.uoc.som.openapi/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+/target/

--- a/plugins/edu.uoc.som.openapi/.gitignore
+++ b/plugins/edu.uoc.som.openapi/.gitignore
@@ -1,2 +1,2 @@
-/bin/
-/target/
+bin/
+target/

--- a/plugins/edu.uoc.som.openapi/.project
+++ b/plugins/edu.uoc.som.openapi/.project
@@ -6,6 +6,27 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.ocl.pivot.ui.oclbuilder</name>
+			<arguments>
+				<dictionary>
+					<key>disabledExtensions</key>
+					<value>*,essentialocl</value>
+				</dictionary>
+				<dictionary>
+					<key>disabledPaths</key>
+					<value>bin/**,target/**</value>
+				</dictionary>
+				<dictionary>
+					<key>enabledExtensions</key>
+					<value>ecore,ocl,oclinecore,oclstdlib,uml</value>
+				</dictionary>
+				<dictionary>
+					<key>enabledPaths</key>
+					<value>**</value>
+				</dictionary>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -25,5 +46,6 @@
 		<nature>org.eclipse.sirius.nature.modelingproject</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.ocl.pivot.ui.oclnature</nature>
 	</natures>
 </projectDescription>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -1,0 +1,18 @@
+<project>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>plugins</artifactId>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>edu.uoc.som.openapi</groupId>
+		<artifactId>openapi-metamodel</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<modules>
+		<module>edu.uoc.som.openapi</module>
+		<module>edu.uoc.som.openapi.io</module>
+	</modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>edu.uoc.som.openapi</groupId>
+  <artifactId>openapi-metamodel</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>OpenAPI for All Metamodel</name>
+  
+	<parent>
+		<groupId>edu.uoc.som.openapi.tycho.configuration</groupId>
+		<artifactId>tycho-configuration</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>./releng/edu.uoc.som.openapi.tycho.configuration</relativePath>
+	</parent>
+
+	<modules>
+		<module>plugins</module>
+		<module>features</module>
+        <module>releng</module>
+	</modules>
+
+</project>

--- a/releng/edu.uoc.som.openapi.tycho.configuration/.project
+++ b/releng/edu.uoc.som.openapi.tycho.configuration/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>edu.uoc.som.openapi.tycho.configuration</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/edu.uoc.som.openapi.tycho.configuration/pom.xml
+++ b/releng/edu.uoc.som.openapi.tycho.configuration/pom.xml
@@ -1,0 +1,84 @@
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>edu.uoc.som.openapi.tycho.configuration</groupId>
+	<artifactId>tycho-configuration</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho.version>1.0.0</tycho.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<eclipse-repo.url>http://download.eclipse.org/releases/oxygen</eclipse-repo.url>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>eclipse-release</id>
+			<url>${eclipse-repo.url}</url>
+			<layout>p2</layout>
+		</repository>
+
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<!--Enable the replacement of the SNAPSHOT version in the final product 
+				configuration -->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<id>package-feature</id>
+						<configuration>
+							<finalName>${project.artifactId}_${unqualifiedVersion}.${buildQualifier}</finalName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86</arch>
+						</environment>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86</arch>
+						</environment>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>
+

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -1,0 +1,16 @@
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>releng</artifactId>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>edu.uoc.som.openapi</groupId>
+		<artifactId>openapi-metamodel</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+       	<relativePath>..</relativePath>
+	</parent>
+
+	<modules>
+        <module>edu.uoc.som.openapi.tycho.configuration</module>
+	</modules>
+</project>


### PR DESCRIPTION
Hi! I use Maven to manage the dependencies and build my projects. Thus, I created a branch in my fork and added a Tycho build config for the openapi-metamodel project. 

Until now, it seems working for my project with no build problems. It not removes the need for Eclipse in the transformation of the Ecore model to the Java classes, but in can be used to compile these classes  (`mvn compile`) and create the JAR package standalone and install it on the local Maven repository (`mvn install`). Also, I did'nt removed the Gson jar from the branch, but I think it may be later externalized to the POM files.


I hope this may have some value for you too.